### PR TITLE
Include replay and server modules in packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,9 @@ scrapli_replay = "scrapli_replay.replay.pytest_scrapli_replay"
 
 [tool.setuptools]
 packages = [
-    "scrapli_replay"
+    "scrapli_replay",
+    "scrapli_replay.replay",
+    "scrapli_replay.server",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
Received a ModuleNotFoundError after pulling 2023.01.30.  The [build steps](https://github.com/scrapli/scrapli_replay/actions/runs/4033325270/jobs/6933767085#step:5:123) appeared to not include the `replay` or `server` modules.   After modifying the build steps showed the following:

~~~
adding 'scrapli_replay/replay/__init__.py'
adding 'scrapli_replay/replay/pytest_scrapli_replay.py'
adding 'scrapli_replay/replay/replay.py'
adding 'scrapli_replay/server/__init__.py'
adding 'scrapli_replay/server/collector.py'
adding 'scrapli_replay/server/server.py'
~~~

The resulting wheel file installed successfully and did not give the ModuleNotFoundError.  
